### PR TITLE
Remove client secret requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Install the SDK using the Maven Central Repository.
     ```
 
 ### Usage
-#### Required IDs and Secrets
-You'll need an `organizationId`, the ID representing your company or organization, along with your `clientSecret`, a semi-secret API
-key that can be bundled into your app.
+#### Required IDs
+You'll need an `organizationId`, the ID representing your company or organization and
+ensure correct attribution.
 
 > **Note**
-> Reach out to [help@bennyapi.com](help@bennyapi.com) to setup your organization and API credentials.
+> Reach out to [help@bennyapi.com](help@bennyapi.com) to setup your organization.
 
 #### Integration
 The Benny Apply flow is contained in a simple view, `BennyApplyFlow`. This view can be programmatically added to any Android Activity or Fragment
@@ -41,7 +41,6 @@ val flow = BennyApplyFlow(
     parameters = BennyApplyParameters(
         credentials = Credentials(
             organizationId = "org_123",
-            clientSecret = "clientsec_123",
         ),
     ),
 )

--- a/benny-android/src/main/java/com/bennyapi/apply/BennyApplyParameters.kt
+++ b/benny-android/src/main/java/com/bennyapi/apply/BennyApplyParameters.kt
@@ -32,18 +32,13 @@ data class BennyApplyParameters(
     }
 
     /**
-     * Credentials used to authenticate the Benny Apply
-     * flow as well as correctly attribute any conversions.
+     * Credentials used to correctly attribute
+     * any conversions to your organization.
      */
     data class Credentials(
         /**
          * The organization ID. Prefixes with "org_".
          */
         val organizationId: String,
-
-        /**
-         * The client secret. Prefixes with "clientsec_".
-         */
-        val clientSecret: String,
     )
 }

--- a/benny-android/src/main/java/com/bennyapi/apply/webview/BennyApplyWebView.kt
+++ b/benny-android/src/main/java/com/bennyapi/apply/webview/BennyApplyWebView.kt
@@ -25,7 +25,6 @@ internal class BennyApplyWebView(
         layoutParams = LayoutParams(MATCH_PARENT, MATCH_PARENT)
         bennyApplyWebViewClient = BennyApplyWebViewClient(
             organizationId = parameters.credentials.organizationId,
-            clientSecret = parameters.credentials.clientSecret,
         )
         webViewClient = bennyApplyWebViewClient
         setWebContentsDebuggingEnabled(parameters.options.isDebuggingEnabled)

--- a/benny-android/src/main/java/com/bennyapi/apply/webview/BennyApplyWebViewClient.kt
+++ b/benny-android/src/main/java/com/bennyapi/apply/webview/BennyApplyWebViewClient.kt
@@ -8,7 +8,6 @@ import com.bennyapi.android.BuildConfig.VERSION
 
 internal class BennyApplyWebViewClient(
     private val organizationId: String,
-    private val clientSecret: String,
 ) : WebViewClient() {
 
     var externalId: String? = null
@@ -25,7 +24,6 @@ internal class BennyApplyWebViewClient(
                     type: 'BENNY_APPLY_INIT',
                     payload: {
                         organizationId: '$organizationId',
-                        clientSecret: '$clientSecret',
                         externalId: '$externalId',
                         sdk: 'android',
                         platform: 'android',

--- a/sample-app/src/main/java/com/bennyapi/MainActivity.kt
+++ b/sample-app/src/main/java/com/bennyapi/MainActivity.kt
@@ -25,7 +25,6 @@ class MainActivity : AppCompatActivity(), BennyApplyListener {
             parameters = BennyApplyParameters(
                 credentials = Credentials(
                     organizationId = "",
-                    clientSecret = "",
                 ),
             ),
         )


### PR DESCRIPTION
The client secret is no longer required to launch the flow, as the organization ID will serve to provide attribution.