### PR TITLE
Ensure Activity Context is used

### DIFF
--- a/benny-android/src/main/java/com/bennyapi/apply/BennyApplyFlow.kt
+++ b/benny-android/src/main/java/com/bennyapi/apply/BennyApplyFlow.kt
@@ -1,21 +1,18 @@
 package com.bennyapi.apply
 
-import android.content.Context
+import android.annotation.SuppressLint
+import android.app.Activity
 import android.widget.FrameLayout
 import android.widget.FrameLayout.LayoutParams.MATCH_PARENT
 import com.bennyapi.apply.webview.BennyApplyWebView
 
+@SuppressLint("ViewConstructor")
 class BennyApplyFlow(
-    context: Context,
-    listener: BennyApplyListener?,
-    parameters: BennyApplyParameters?,
-) : FrameLayout(context) {
-    private val webView = BennyApplyWebView(context, listener!!, parameters!!)
-
-    /**
-     * Default constructor to enable view development or snapshot testing
-     */
-    constructor(context: Context) : this(context, null, null)
+    activity: Activity,
+    listener: BennyApplyListener,
+    parameters: BennyApplyParameters,
+) : FrameLayout(activity) {
+    private val webView = BennyApplyWebView(activity, listener, parameters)
 
     init {
         layoutParams = LayoutParams(MATCH_PARENT, MATCH_PARENT)

--- a/benny-android/src/main/java/com/bennyapi/apply/webview/BennyApplyWebView.kt
+++ b/benny-android/src/main/java/com/bennyapi/apply/webview/BennyApplyWebView.kt
@@ -11,10 +11,10 @@ import com.bennyapi.apply.BennyApplyParameters.Options.Environment.STAGING
 
 @SuppressLint("SetJavaScriptEnabled", "ViewConstructor")
 internal class BennyApplyWebView(
-    context: Context,
+    activityContext: Context,
     listener: BennyApplyListener,
     parameters: BennyApplyParameters,
-) : WebView(context) {
+) : WebView(activityContext) {
     private val baseUrl: String
     private val organizationId: String
     private val bennyApplyWebViewClient: BennyApplyWebViewClient

--- a/sample-app/src/main/java/com/bennyapi/MainActivity.kt
+++ b/sample-app/src/main/java/com/bennyapi/MainActivity.kt
@@ -19,7 +19,7 @@ class MainActivity : AppCompatActivity(), BennyApplyListener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.main)
         flow = BennyApplyFlow(
-            context = applicationContext,
+            activity = this,
             listener = this,
             parameters = BennyApplyParameters(
                 organizationId = "",


### PR DESCRIPTION
Activity Context rather than Application Context is required to ensure that Android date and select options correctly appear.