### PR TITLE
Correct organizationId query parameter

### DIFF
--- a/benny-android/src/main/java/com/bennyapi/apply/webview/BennyApplyWebView.kt
+++ b/benny-android/src/main/java/com/bennyapi/apply/webview/BennyApplyWebView.kt
@@ -46,6 +46,6 @@ internal class BennyApplyWebView(
     }
 
     internal fun start(externalId: String) {
-        loadUrl("$baseUrl?$organizationId&externalId=$externalId&isWebView=true")
+        loadUrl("$baseUrl?organizationId=$organizationId&externalId=$externalId&isWebView=true")
     }
 }


### PR DESCRIPTION
Prior to this change the `organizationId` query parameter was incorrectly set.