### PR TITLE
Add onLinkResult to share more information with client

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install the SDK using the Maven Central Repository.
 
     ```Gradle
     dependencies {
-        implementation("com.bennyapi:benny-android:1.1.0")
+        implementation("com.bennyapi:benny-android:1.1.1")
     }
     ```
 
@@ -79,12 +79,12 @@ See [Sample App](sample-app) as an example integration.
 #### Listening for Flow Events
 
 The `EbtBalanceLinkFlowListener` is responsible for communicating to your Android app when the
-user wants to exit the flow and when a link is successful.
+user wants to exit the flow and on link result.
 
 ```Kotlin
 interface EbtBalanceLinkFlowListener {
     fun onExit()
-    fun onLinkSuccess(linkToken: String)
+    fun onLinkResult(linkToken: String)
 }
 ```
 

--- a/benny-android/build.gradle.kts
+++ b/benny-android/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     alias(libs.plugins.maven.publish)
+    kotlin("plugin.serialization")
 }
 
 val sdkVersion = "1.1.0"
@@ -80,4 +81,5 @@ mavenPublishing {
 
 dependencies {
     implementation(libs.androidx.core.ktx)
+    implementation(libs.kotlin.serialization)
 }

--- a/benny-android/src/main/java/com/bennyapi/ebtbalancelink/EbtBalanceLinkFlowListener.kt
+++ b/benny-android/src/main/java/com/bennyapi/ebtbalancelink/EbtBalanceLinkFlowListener.kt
@@ -1,8 +1,16 @@
 package com.bennyapi.ebtbalancelink
 
+import com.bennyapi.ebtbalancelink.result.LinkResult
+
 interface EbtBalanceLinkFlowListener {
 
     fun onExit()
 
-    fun onLinkSuccess(linkToken: String)
+    /**
+     * @deprecated use [onLinkResult] as this method will
+     * be removed in a future released.
+     */
+    fun onLinkSuccess(linkToken: String) {}
+
+    fun onLinkResult(result: LinkResult)
 }

--- a/benny-android/src/main/java/com/bennyapi/ebtbalancelink/result/LinkResult.kt
+++ b/benny-android/src/main/java/com/bennyapi/ebtbalancelink/result/LinkResult.kt
@@ -1,0 +1,25 @@
+package com.bennyapi.ebtbalancelink.result
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LinkResult(
+    val type: String = "LinkResultSuccess",
+    val linkToken: String,
+    val accountId: String,
+    val accountHolder: AccountHolder,
+)
+
+@Serializable
+data class AccountHolder(
+    val name: String?,
+    val address: String?,
+    val balances: Balances,
+    val lastTransactionDate: String?,
+)
+
+@Serializable
+data class Balances(
+    val snap: Int?,
+    val cash: Int?,
+)

--- a/benny-android/src/main/java/com/bennyapi/ebtbalancelink/webview/EbtBalanceLinkJavascriptInterface.kt
+++ b/benny-android/src/main/java/com/bennyapi/ebtbalancelink/webview/EbtBalanceLinkJavascriptInterface.kt
@@ -9,6 +9,12 @@ import android.net.Uri.parse
 import android.webkit.JavascriptInterface
 import androidx.core.content.ContextCompat.startActivity
 import com.bennyapi.ebtbalancelink.EbtBalanceLinkFlowListener
+import kotlinx.serialization.json.Json
+
+private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+}
 
 internal class EbtBalanceLinkJavascriptInterface(
     private val listener: EbtBalanceLinkFlowListener,
@@ -23,6 +29,12 @@ internal class EbtBalanceLinkJavascriptInterface(
     @JavascriptInterface
     fun onExit() = listener.onExit()
 
+    @JavascriptInterface
+    fun onLinkResult(resultJsonString: String) = listener.onLinkResult(json.decodeFromString(resultJsonString))
+
+    /**
+     * @deprecated use [onLinkResult].
+     */
     @JavascriptInterface
     fun onLinkSuccess(linkToken: String) = listener.onLinkSuccess(linkToken = linkToken)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.android.library") version "8.3.0" apply false
     id("com.diffplug.spotless") version "6.22.0" apply true
     id("com.github.ben-manes.versions") version "0.49.0" apply true
+    kotlin("plugin.serialization") version "1.9.22" apply false
 }
 
 spotless {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,13 @@
 [versions]
-androidx-core-ktx = "1.12.0"
+androidx-core-ktx = "1.13.0"
 appcompat = "1.6.1"
+kotlin-serialization = "1.6.3"
 maven-publish = "0.28.0"
 
 [libraries]
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core-ktx" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
+kotlin-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlin-serialization" }
 
 [plugins]
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample-app/src/main/java/com/bennyapi/MainActivity.kt
+++ b/sample-app/src/main/java/com/bennyapi/MainActivity.kt
@@ -10,6 +10,7 @@ import com.bennyapi.ebtbalancelink.EbtBalanceLinkFlowListener
 import com.bennyapi.ebtbalancelink.EbtBalanceLinkFlowParameters
 import com.bennyapi.ebtbalancelink.EbtBalanceLinkFlowParameters.Options
 import com.bennyapi.ebtbalancelink.EbtBalanceLinkFlowParameters.Options.Environment.SANDBOX
+import com.bennyapi.ebtbalancelink.result.LinkResult
 
 private const val LOG_TAG = "Benny"
 
@@ -48,7 +49,7 @@ class MainActivity : AppCompatActivity(), EbtBalanceLinkFlowListener {
         Log.d(LOG_TAG, "onExit called.")
     }
 
-    override fun onLinkSuccess(linkToken: String) {
-        Log.d(LOG_TAG, "onLinkSuccess called: $linkToken.")
+    override fun onLinkResult(result: LinkResult) {
+        Log.d(LOG_TAG, "onLinkResult called: $result.")
     }
 }


### PR DESCRIPTION
Introduces `onLinkResult` to replace `onLinkSuccess` and to share more information with SDK consumers beyond the link token.