### PR TITLE
Do not override URL loading

### DIFF
--- a/benny-android/src/main/java/com/bennyapi/ebtbalancelink/webview/EbtBalanceLinkWebViewClient.kt
+++ b/benny-android/src/main/java/com/bennyapi/ebtbalancelink/webview/EbtBalanceLinkWebViewClient.kt
@@ -1,14 +1,11 @@
 package com.bennyapi.ebtbalancelink.webview
 
-import android.content.Intent
-import android.content.Intent.ACTION_VIEW
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 
 internal class EbtBalanceLinkWebViewClient : WebViewClient() {
     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
-        view.context.startActivity(Intent(ACTION_VIEW, request.url))
-        return true
+        return false
     }
 }


### PR DESCRIPTION
On redirects (and other cases), URLs should not be overridden.